### PR TITLE
php71 fix with css classes array and assign-op operator

### DIFF
--- a/classes/ContentHook.php
+++ b/classes/ContentHook.php
@@ -101,7 +101,7 @@ class ContentHook extends \Frontend {
 			}
 
 			if($classes != ''){
-				$arrCss = \Contao\StringUtil::deserialize($objElement->cssID);
+				$arrCss = \Contao\StringUtil::deserialize($objElement->cssID, true);
 				$arrCss[1] .= $classes;
 				$newObjElement->cssID = $arrCss;
 			}


### PR DESCRIPTION
Kann es immer noch nicht 100% sagen, dass es an der PHP Version liegt, aber da ich nur lokal das Problem habe und hier 7.1 läuft gehe ich stark davon aus. 
Der kleine Fix der von Contaos deserialize ein Array forced reicht schon aus um das Problem zu beheben. 
Bei mir war es der Fall dass deserialize einen Leerstring ausspuckte. Wundern tut mich hier dass PHP nicht schon früher schreit dass es keinen Index 1 gibt, aber gut. So sollte es auf jeden Fall abgesichert sein.